### PR TITLE
Display patch on pedal and retrieve current patch from pedal

### DIFF
--- a/zoom-multistomp-patch-changer.ino
+++ b/zoom-multistomp-patch-changer.ino
@@ -58,8 +58,8 @@ bool      			_btNextDown = false;
 bool      			_btPrevDown = false;
 bool      			_isScrolling = false;
 bool 				_cancelScroll = false;
-OneButton 			_btNext(A1, true);
-OneButton 			_btPrev(A2, true);
+OneButton 			_btNext(PIN_BUTTON_PREV, true);
+OneButton 			_btPrev(PIN_BUTTON_NEXT, true);
 
 // display stuff
 Adafruit_SSD1306 	_display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, PIN_OLED_RESET);
@@ -146,12 +146,17 @@ void debugReadBuffer(const __FlashStringHelper * aMessage, bool aIsSysEx) {
 // ZOOM DEVICE HELPERS
 // ----------------------------------------------------------------------------
 void incPatch(int8_t aOffset) {
-    _currentPatch = _currentPatch + aOffset;
+
+    enableEditorMode(true);
+    requestPatchIndex();
+
+      _currentPatch = _currentPatch + aOffset;
     _currentPatch = _currentPatch > (DEV_MAX_PATCHES - 1) ? 0 : _currentPatch;
     _currentPatch = _currentPatch < 0 ? (DEV_MAX_PATCHES -1) : _currentPatch;
 
     sendPatch();
     requestPatchData();
+    enableEditorMode(false);
     updateDisplay();
 }
 
@@ -282,8 +287,8 @@ void initDevice() {
     _display.println(fw_version);
     _display.display();
 
-    requestPatchIndex();
     enableEditorMode(true);
+    requestPatchIndex();
     requestPatchData();
     delay(1500);
 }


### PR DESCRIPTION
HI, added 2 features:

- By sending the pedal out of edit mode it causes the patch name to be displayed on the pedal (handy if don't have the screen)
- Added code to retrieve the current patch from the pedal. e.g. if someone was on patch 6 then used the middle dial to select patch 20, then they hit the next button the pedal changes to patch 21 rather than 7

I had to add 3 retries to the path retrieval because in some cases it fails, at least on my MS-50G